### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,7 +15,7 @@ if ! [[ "$1" =~ ^(web|worker|cron)$ ]]; then
 fi
 
 # Wait for MySQL
-while ! mysqladmin ping -h$DB_HOST -u$MYSQL_USER -p$MYSQL_PASSWORD --silent; do
+while ! mysqladmin ping -h$DB_HOST -u$DB_USERNAME -p$DB_PASSWORD --silent; do
     echo "MariaDB container might not be ready yet. Sleeping..."
     sleep 3
 done


### PR DESCRIPTION
Fixed missing MYSQL_* variables (no longer present in the .env file) so that the wait-for-MariaDB step uses the correct variables. Without the correct variables it repeatedly fails to check whether or not the DB server is up.

The docker-compose YAML file correctly wires in the values from .env to SET the MYSQL_* variables in the MariaDB container, but other containers which wait on MariaDB use them to run the ping command.

Aside: there may be more secure ways to decide that the MariaDB container is up than actually making a connection to it using mysqladmin and a user/password, like checking if the correct port is listening for/accepting connections.