### PR TITLE
Respect DB_PORT variable in docker entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,7 +15,7 @@ if ! [[ "$1" =~ ^(web|worker|cron)$ ]]; then
 fi
 
 # Wait for MySQL
-while ! mysqladmin ping -h$DB_HOST -u$DB_USERNAME -p$DB_PASSWORD --silent; do
+while ! mysqladmin ping -h$DB_HOST -u$DB_USERNAME -p$DB_PASSWORD -P${DB_PORT:-3306} --silent; do
     echo "MariaDB container might not be ready yet. Sleeping..."
     sleep 3
 done


### PR DESCRIPTION
This allows people to use these containers with mysql services that
aren't on the default port, the actual php programs respect the
`DB_PORT` env variable, it was just this ping code that didn't.