### PR TITLE
feat: add dev ability to new docker stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get install -y --no-install-recommends \
     zip unzip mariadb-client redis-tools \
     libzip-dev libpq-dev libpng-dev libjpeg-dev libgmp-dev libbz2-dev libfreetype6-dev libicu-dev \
+    jq \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
     image: eveseat/seat:4
     restart: always
     command: web
+    volumes:
+      - ./packages:/var/www/seat/packages:ro
     env_file:
       - .env
     labels:
@@ -97,6 +99,8 @@ services:
     image: eveseat/seat:4
     restart: always
     command: worker
+    volumes:
+      - ./packages:/var/www/seat/packages:ro
     env_file:
       - .env
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,7 +106,7 @@ function start_web_service() {
     composer dump-autoload
 
     echo "Fixing permissions"
-    chown -R www-data:www-data /var/www/seat
+    find /tmp/www/seat -path /tmp/www/seat/packages -prune -o -exec chown www-data:www-data {} +
 
     # lets 🚀
     apache2-foreground

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,6 +93,9 @@ function register_dev_packages() {
     # use PHP in order to register providers
     php -r 'require "vendor/autoload.php"; $config = require "config/app.php.bak"; $override = json_decode(file_get_contents("packages/override.json")); $config["providers"] = array_merge($config["providers"], $override->providers ?? []); file_put_contents("config/app.php", "<?php return " . var_export($config, true) . ";");'
 
+    # Refresh composer setup
+    composer update
+
     # Redump the autoloader
     composer dump-autoload
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -72,8 +72,8 @@ function install_plugins() {
 
 function register_dev_packages() {
 
-    echo "autoload.json overrider has been detected."
-    echo "Merging composer.json and autoload.json together..."
+    echo "override.json has been detected."
+    echo "Merging composer.json and override.json together..."
 
     # take a backup from original composer.json
     if [ ! -f "composer.json.bak" ]; then
@@ -81,7 +81,7 @@ function register_dev_packages() {
     fi
 
     # use JQ in order to merge both overrider and sourcing composer.json
-    jq -s '.[0] as $composer | .[1] as $overrider | $composer | ."autoload-dev"."psr-4" = $composer."autoload-dev"."psr-4" + $overrider.autoload' composer.json.bak packages/autoload.json > composer.json
+    jq -s '.[0] as $composer | .[1] as $overrider | $composer | ."autoload-dev"."psr-4" = $composer."autoload-dev"."psr-4" + $overrider.autoload' composer.json.bak packages/override.json > composer.json
 
     echo "Registering providers manually..."
 
@@ -91,7 +91,7 @@ function register_dev_packages() {
     fi
 
     # use PHP in order to register providers
-    php -r 'require "vendor/autoload.php"; $config = require "config/app.php.bak"; $override = json_decode(file_get_contents("packages/autoload.json")); $config["providers"] = array_merge($config["providers"], $override->providers ?? []); file_put_contents("config/app.php", "<?php return " . var_export($config, true) . ";");'
+    php -r 'require "vendor/autoload.php"; $config = require "config/app.php.bak"; $override = json_decode(file_get_contents("packages/override.json")); $config["providers"] = array_merge($config["providers"], $override->providers ?? []); file_put_contents("config/app.php", "<?php return " . var_export($config, true) . ";");'
 
     # Redump the autoloader
     composer dump-autoload
@@ -124,7 +124,7 @@ function start_web_service() {
     install_plugins "migrate"
 
     # register dev packages if setup
-    test -f packages/autoload.json && register_dev_packages "migrate"
+    test -f packages/override.json && register_dev_packages "migrate"
 
     echo "Dumping the autoloader"
     composer dump-autoload
@@ -146,7 +146,7 @@ function start_worker_service() {
     install_plugins
 
     # register dev packages if setup
-    test -f packages/autoload.json && register_dev_packages
+    test -f packages/override.json && register_dev_packages
 
     # fix up permissions for the storage directory
     chown -R www-data:www-data storage
@@ -164,7 +164,7 @@ function start_cron_service() {
     install_plugins
 
     # register dev packages if setup
-    test -f packages/autoload.json && register_dev_packages
+    test -f packages/override.json && register_dev_packages
 
     echo "starting 'cron' loop"
 


### PR DESCRIPTION
Purpose of the pull request is to provide a way to develop using the same Docker stack than the production one.

It will bind a new directory (`packages`) in read only-mode into which developper can put all his developments packages.
In order to load them, it will add a file at root of that new directory called `override.json` and containing a valid Composer PSR-4 object as bellow :

```
{
    "autoload" : {
        "Seat\\Api\\": "packages/eveseat/api/src/",
        "Seat\\Console\\": "packages/eveseat/console/src/",
        "Seat\\Eveapi\\": "packages/eveseat/eveapi/src/",
        "Seat\\Notifications\\": "packages/eveseat/notifications/src/",
        "Seat\\Services\\": "packages/eveseat/services/src/",
        "Seat\\Web\\": "packages/eveseat/web/src/",
        "Seat\\Eseye\\": "packages/eveseat/eseye/src/"
   } 
}
```

During container startup, we will check for that specific file existence and merge its content together with original `composer.json` at this path : `"autoload-dev"."psr-4"`. A backup of the original file will be took and stored at `/var/www/seat/composer.json.bak`

Also, since package discovery is working only for packages inside `vendor` directory, we will register provided providers manually by merging content from `providers` property into `providers` from `config/app.php`. At startup, the file will be backup at `/var/www/seat/config/app.php.bak` and the newly merged configuration will be output into `/var/www/seat/config/app.php`.

The complete `override.json` file structure must be as bellow :

```
{
     "autoload" : { ...}, // PSR-4 class map definition
     "providers" : [ ... ] // FQCN Providers class list
}
```

Json manipulation is made using the amazing library `jq`
 - https://stedolan.github.io/jq/
 - https://www.youtube.com/watch?v=uIKvYgix-L4