### PR TITLE
feat: improve quick-install user experience

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,7 +17,7 @@ echo "SeAT installation."
 echo
 echo "Everything will live in $SEAT_DOCKER_INSTALL"
 
-read -p "Are you sure you want to continue? [y/n] " -n 1 -r
+read -p "Are you sure you want to continue? [Y/n] " -n 1 -r
 echo    # (optional) move to a new line
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then
@@ -65,6 +65,7 @@ echo "Ensuring $SEAT_DOCKER_INSTALL is available..."
 mkdir -p $SEAT_DOCKER_INSTALL
 cd $SEAT_DOCKER_INSTALL
 
+echo    # (optional) move to a new line
 echo "Grabbing docker-compose and .env file"
 curl -L https://raw.githubusercontent.com/eveseat/seat-docker/master/docker-compose.yml \
     -o $SEAT_DOCKER_INSTALL/docker-compose.yml
@@ -76,13 +77,73 @@ sed -i -- 's/DB_PASSWORD=i_should_be_changed/DB_PASSWORD='$(head /dev/urandom | 
 echo "Generating an application key and writing it to the .env file."
 sed -i -- 's/APP_KEY=insecure/APP_KEY='$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c32 ; echo '')'/g' .env
 
+echo    # (optional) move to a new line
+echo "Setup the domain"
+while true; do
+  while [ -z "$TRAEFIK_DOMAIN" ]
+  do
+    read -p "SeAT root domain (eg: example.com): " TRAEFIK_DOMAIN
+  done
+
+  while [ -z "$SEAT_SUBDOMAIN" ]
+  do
+    read -p "SeAT subdomain (eg: seat): " SEAT_SUBDOMAIN
+  done
+
+  read -p "SeAT will be served over https://${SEAT_SUBDOMAIN}.${TRAEFIK_DOMAIN} - is that correct ? [Y/n]" -n 1 -r
+  echo    # (optional) move to a new line
+  case $REPLY in
+    [yY]|"") sed -i -- 's/TRAEFIK_DOMAIN=seat.local/TRAEFIK_DOMAIN='"${TRAEFIK_DOMAIN}"'/g' .env
+      sed -i -- 's/SEAT_SUBDOMAIN=seat/SEAT_SUBDOMAIN='"${SEAT_SUBDOMAIN}"'/g' .env
+      break ;;
+    *) TRAEFIK_DOMAIN=''
+       SEAT_SUBDOMAIN=''
+       echo "No changes have been applied. Please provide the root domain and sub-domain on which SeAT will be served"
+  esac
+done
+
+echo "Enabling SSL entrypoint"
+echo "Please provide a valid e-mail address for Let's Encrypt account creation (this service will handle your SSL certificates) - leave empty to not use SSL"
+read -p "e-mail: " ACME_EMAIL
+if [ -n "$ACME_EMAIL" ]; then
+  sed -i -- 's/TRAEFIK_ACME_EMAIL=you@domain.com/TRAEFIK_ACME_EMAIL='"${ACME_EMAIL}"'/g' .env
+  sed -i -- 's/      #- "traefik.http.routers.seat-web.tls.certResolver=primary/      - "traefik.http.routers.seat-web.tls.certResolver=primary"/g' docker-compose.yml
+else
+  echo "No e-mail address has been provided, SSL will not be available"
+  echo "SeAT will be reachable on http://${SEAT_SUBDOMAIN}.${TRAEFIK_DOMAIN} only"
+fi
+
 echo "Preparing an acme.json file for Traefik and Let's Encrypt"
 mkdir acme
 touch acme/acme.json
 chmod 600 acme/acme.json
 
+echo    # (optional) move to a new line
+echo "Setup EVE Online Application"
+echo "Please go to https://developers.eveonline.com/applications/create in order to create a new application"
+
+if [ -n "$ACME_EMAIL" ]; then
+  echo "You must use https://${SEAT_SUBDOMAIN}.${TRAEFIK_DOMAIN}/auth/eve/callback as callback"
+else
+  echo "You must use http://${SEAT_SUBDOMAIN}.${TRAEFIK_DOMAIN}/auth/eve/callback as callback"
+fi
+
+while [ -z "$CLIENT_ID" ]
+do
+  read -p "Client ID: " CLIENT_ID
+done
+
+while [ -z "$CLIENT_SECRET" ]
+do
+  read -p "Secret Key: " CLIENT_SECRET
+done
+
+sed -i -- 's/EVE_CLIENT_ID=null/EVE_CLIENT_ID='"${CLIENT_ID}"'/g' .env
+sed -i -- 's/EVE_CLIENT_SECRET=null/EVE_CLIENT_SECRET='"${CLIENT_SECRET}"'/g' .env
+
+echo    # (optional) move to a new line
 echo "Starting docker stack. This will download the images too. Please wait..."
 docker-compose up -d
 
-echo "Done! The containers are now iniliatising. To check what is happening, run 'docker-compose logs --tail 5 -f' in /opt/seat-docker"
-
+echo    # (optional) move to a new line
+echo "Done! The containers are now initialising. To check what is happening, run 'docker-compose logs --tail 5 -f' in ${SEAT_DOCKER_INSTALL}"


### PR DESCRIPTION
This improve a little bit the user experience for those using quick-install by asking them :
- the domain to be used
- the CNAME to be used
- the ACME account mail address to be used
- the Eve Client ID to be used
- the Eve Client Secret to be used

I hope it makes the flow more accessible for IT noobs.
By the meanwhile, it will address those two :
- documentation flow : we ask user to go up to the monitoring stack section after running this script
- deployment flow : we start the stack without required informations