### PR TITLE
ci: trigger workflow on all push but run it only if tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ name: Docker build & Push
 
 # Controls when the action will run. 
 on:
+  push:
+    branches: [ master ]
   release:
     types: [ published ]
 
@@ -16,7 +18,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    # Only if tag
+    if: startsWith(github.ref, 'refs/tags/')
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
reverting change regarding trigger (on push event) since a tag isn't linked to a release event.
use a conditional check in order to determine if yes or no job must be proceed.

https://stackoverflow.com/questions/58475748/github-actions-how-to-check-if-current-push-has-new-tag-is-new-release
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#determining-when-to-use-contexts