### PR TITLE
Make cron use same package overrides as worker & web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,8 @@ services:
     image: eveseat/seat:4
     restart: always
     command: cron
+    volumes:
+      - ./packages:/var/www/seat/packages:ro  # development only
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
Without this, the web and worker containers may use overridden packages, while cron will not. This makes developing cron jobs much more difficult.