### PR TITLE
Various compose file updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         max-file: "5"
 
   traefik:
-    image: traefik:2.2
+    image: traefik:2.9
     restart: always
     command:
       - --log.level=INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
         max-file: "5"
 
   redis:
-    image: redis:5-alpine
+    image: redis:7-alpine
     restart: always
     networks:
       - seat-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - "mariadb-data:/var/lib/mysql"
     networks:
       - seat-network
+    ulimits:
+      memlock: -1
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: mariadb:10
     restart: always
     environment:
+      MARIADB_AUTO_UPGRADE: "yes"
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}


### PR DESCRIPTION
For one, this updates redis and traefik to their respective latest version.
The redis update should be entirely unproblematic in itself.
For traefik, none of the various breaking changes they did affect the rather simple setup in the SeAT compose file.

The other two updates are for MariaDB.
For one, I noticed that the mariadb log on our instance was full of errors about missing columns and tables in the mysql database, which was resolved by running the upgrade script.
Adding this option runs it automatically when necessary.
Additionally, after the Update to Ubuntu 22.04, mariadb started complaining about too low of a memlock limit, which forced it to disable io_uring support, degrading performance. The limit can be lifted again via the compose file.