### PR TITLE
docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,7 @@ RUN cd /var/www && \
     chown -R www-data:www-data /var/www/seat && \
     cd /var/www/seat && \
     # Setup the default configuration file
-    php -r "file_exists('.env') || copy('.env.example', '.env');" && \
-    # Publish assets and generate API documentation
-    php artisan vendor:publish --force --all
-#    php artisan l5-swagger:generate
+    php -r "file_exists('.env') || copy('.env.example', '.env');"
 
 # Expose only the public directory to Apache
 RUN rmdir /var/www/html && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -138,7 +138,7 @@ function start_web_service() {
     #find /var/www/seat -path /var/www/seat/packages -prune -o -exec chown www-data:www-data {} +
 
     # lets 🚀
-    apache2-foreground
+    exec apache2-foreground
 }
 
 # start_worker_service
@@ -150,7 +150,7 @@ function start_worker_service() {
 
     update_stack
 
-    php artisan horizon
+    exec php artisan horizon
 }
 
 # start_cron_service


### PR DESCRIPTION
There is no point in publishing assets and generating documentations, because the `docker-entrypoint.sh` script does it again when starting up the stack, so plugins get processed too.