### PR TITLE
fix: avoid networking issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,16 @@ RUN cd /var/www && \
 RUN rmdir /var/www/html && \
     ln -s /var/www/seat/public /var/www/html
 RUN a2enmod rewrite
-EXPOSE 80
+
+# Changing default Apache port to allow rootless container exploitation
+#
+# If the Listen specified in the configuration file is default of 80 (or any other port below 1024),
+# then it is necessary to have root privileges in order to start apache, so that it can bind to this privileged port.
+# Once the server has started and performed a few preliminary activities such as opening its log files, it will launch
+# several child processes which do the work of listening for and answering requests from clients. The main httpd process
+# continues to run as the root user, but the child processes run as a less privileged user.
+
+RUN sed -i 's/80/8080/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
 
 WORKDIR /var/www/seat
 
@@ -47,4 +56,5 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 
 USER seat
+EXPOSE 8080
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -4,7 +4,7 @@ services:
 
   front:
     ports:
-      - "127.0.0.1:${PROXY_BACKEND_HTTP_PORT}:80"
+      - "127.0.0.1:${PROXY_BACKEND_HTTP_PORT}:8080"
     networks:
       - seat-frontend
 

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -25,8 +25,8 @@ services:
       - --certificatesresolvers.primary.acme.httpchallenge=true
       - --certificatesresolvers.primary.acme.httpchallenge.entrypoint=http
     ports:
-      - ${TRAEFIK_HTTP_PORT}:80
-      - ${TRAEFIK_HTTPS_PORT}:443
+      - "${TRAEFIK_HTTP_PORT}:80"
+      - "${TRAEFIK_HTTPS_PORT}:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./acme/acme.json:/acme.json
@@ -43,7 +43,12 @@ services:
       - seat-frontend
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=seat-frontend"
+      - "traefik.docker.network=${COMPOSE_PROJECT_NAME}_seat-frontend"
+      - "traefik.http.routers.seat.entrypoints=https"
+      - "traefik.http.routers.seat.service=seat-front"
+      - "traefik.http.routers.seat.middlewares=seat-security@docker"
+      - "traefik.http.routers.seat.rule=Host(`${SEAT_DOMAIN}`)"
+      - "traefik.http.routers.seat.tls.certResolver=primary"
       - "traefik.http.middlewares.seat-security.headers.browserxssfilter=false"
       - "traefik.http.middlewares.seat-security.headers.contentSecurityPolicy=default-src 'none'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.bunny.net https://snoopy.crypta.tech; img-src 'self' data: https://images.evetech.net; font-src 'self' https://fonts.gstatic.com https://fonts.bunny.net; manifest-src 'self'"
       - "traefik.http.middlewares.seat-security.headers.contentTypeNoSniff=true"
@@ -58,10 +63,7 @@ services:
       - "traefik.http.middlewares.seat-security.headers.stsIncludeSubdomains=true"
       - "traefik.http.middlewares.seat-security.headers.stsPreload=true"
       - "traefik.http.middlewares.seat-security.headers.stsSeconds=63072000"
-      - "traefik.http.routers.seat.entrypoints=https"
-      - "traefik.http.routers.seat.middlewares=seat-security@docker"
-      - "traefik.http.routers.seat.rule=Host(`${SEAT_DOMAIN}`)"
-      - "traefik.http.routers.seat.tls.certResolver=primary"
+      - "traefik.http.services.seat-front.loadbalancer.server.port=8080"
 
 networks:
   seat-frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - .env
     depends_on:
       - cache
+      - front
     networks:
       - seat-gateway
       - seat-internal
@@ -53,6 +54,7 @@ services:
       - .env
     depends_on:
       - cache
+      - worker
     networks:
       - seat-gateway
       - seat-internal


### PR DESCRIPTION
- when using traefik stack, ensure proper network is used (network are prefixed with project name)
- avoid port listening issues in rootless