### PR TITLE
add img.shields.io as image source to CSP headers

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -50,7 +50,7 @@ services:
       - "traefik.http.routers.seat.rule=Host(`${SEAT_DOMAIN}`)"
       - "traefik.http.routers.seat.tls.certResolver=primary"
       - "traefik.http.middlewares.seat-security.headers.browserxssfilter=false"
-      - "traefik.http.middlewares.seat-security.headers.contentSecurityPolicy=default-src 'none'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.bunny.net https://snoopy.crypta.tech; img-src 'self' data: https://images.evetech.net; font-src 'self' https://fonts.gstatic.com https://fonts.bunny.net; manifest-src 'self'"
+      - "traefik.http.middlewares.seat-security.headers.contentSecurityPolicy=default-src 'none'; connect-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.bunny.net https://snoopy.crypta.tech; img-src 'self' data: https://images.evetech.net https://img.shields.io; font-src 'self' https://fonts.gstatic.com https://fonts.bunny.net; manifest-src 'self'"
       - "traefik.http.middlewares.seat-security.headers.contentTypeNoSniff=true"
       - "traefik.http.middlewares.seat-security.headers.customBrowserXSSValue=0"
       - "traefik.http.middlewares.seat-security.headers.customresponseheaders.Server="


### PR DESCRIPTION
from @Kiba from discord:

With the Traefik config, the CSP doesn't allow images from https://img.shields.io which is where the admin portal gets its packagist version images for embedding, I was getting some broken images with the original configuration that is part of the default Traefik config provided. Was a pretty simple fix of adding https://img.shields.io to the img-src section of the Traefik traefik.http.middlewares.seat-security.headers.contentSecurityPolicy config.
