### PR TITLE
Fix broken SeAT 4 setups while always newest version is set in composer.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV COMPOSER_MEMORY_LIMIT -1
 
 # Install SeAT
 RUN cd /var/www && \
-    composer create-project eveseat/seat --stability beta --no-scripts --no-dev --no-ansi --no-progress && \
+    composer create-project eveseat/seat:^4.0 --stability beta --no-scripts --no-dev --no-ansi --no-progress && \
     composer clear-cache --no-ansi && \
     # Fix up the source permissions to be owned by www-data
     chown -R www-data:www-data /var/www/seat && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,7 +47,7 @@ function install_plugins() {
         #   ref: https://github.com/composer/composer/issues/1874
 
         # Require the plugins from the environment variable.
-        composer require ${plugins} --no-update
+        composer require ${plugins} --no-install
 
         # Update the plugins.
         composer update ${plugins} --no-scripts --no-dev --no-ansi --no-progress


### PR DESCRIPTION
After release packages for SeAT 5 most docker setups break after restart them with down / up. This occures while plugins not correct defined on entrypoint.