### PR TITLE
Add `linux/arm/v8` to container builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
           - linux/amd64
           - linux/arm64
           - linux/arm/v7
+          - linux/arm/v8
         image:
           - eveseat/seat
           - ghcr.io/eveseat/seat


### PR DESCRIPTION
Noticed when relocating my installation that `linux/arm/v8` wasn't supported by the existing images, this simply adds this to the builds.

This is needed to support some systems out there one example being Ampere.