### PR TITLE
fix: remove obsolete version statement

### DIFF
--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
 
   mariadb:

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
 
   front:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
 
   traefik:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.2"
-
 services:
 
   front:


### PR DESCRIPTION
Our docker-compose files include a top-level `version` statement. This is deprecated by docker(https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete) and throws a warning whenever executing any `docker compose <xxx>` commands: 
```
WARN[0000] /Users/me/seat-dev-5/docker-compose.yml: `version` is obsolete
```
This PR removes the version statements from our docker-compose files to supress this warning.