### PR TITLE
2.10 is EOL and also has a few known CVE's that affect it.

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,7 +1,7 @@
 services:
 
   traefik:
-    image: traefik:2.10
+    image: traefik:v3
     restart: always
     depends_on:
       - front

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,7 +1,7 @@
 services:
 
   traefik:
-    image: traefik:v3
+    image: traefik:3.6
     restart: always
     depends_on:
       - front


### PR DESCRIPTION
While helping out in the Discord, I noticed we were still using an older version of Traefik.

Per their [deprecation policy](https://doc.traefik.io/traefik/deprecation/releases/), it's a good idea to move to the v3 series to stay within the supported range. This way, we’ll continue getting bug fixes and CVE patches right up until v4 drops.

This PR bumps us to v3. If needed, we can pin to something like 3.3, but sticking with v3 keeps things up to date without much hassle.